### PR TITLE
Introduce timestepsPerCollisionDetection factor

### DIFF
--- a/cfg/default_cfg.yaml
+++ b/cfg/default_cfg.yaml
@@ -5,6 +5,7 @@ sim:
   minAltitude: 150 # Everything below this altitude above ground will be considered burning up [km]
   deltaT: 10.0 # [s]
   collisionDistanceFactor: 1.0 # Factor multiplied with the sum of radii to over approximate collision distances.
+  timestepsPerCollisionDetection: 1
 
   prop: # Which propagation model components should be applied
     useKEPComponent: true # Keplerian propagation

--- a/src/ladds/Simulation.h
+++ b/src/ladds/Simulation.h
@@ -100,11 +100,12 @@ class Simulation {
    * @param autopas
    * @param integrator
    * @param config
+   * @return Number of observed collisions.
    */
-  void simulationLoop(AutoPas_t &autopas,
-                      Integrator<AutoPas_t> &integrator,
-                      std::vector<Constellation> &constellations,
-                      ConfigReader &config);
+  [[maybe_unused]] size_t simulationLoop(AutoPas_t &autopas,
+                                         Integrator<AutoPas_t> &integrator,
+                                         std::vector<Constellation> &constellations,
+                                         ConfigReader &config);
 
   /**
    * Inserts particles into autopas if they have a safe distance to existing particles.

--- a/tests/testladds/SimulationTest.h
+++ b/tests/testladds/SimulationTest.h
@@ -24,7 +24,8 @@ class SimulationTest : public testing::TestWithParam<ParameterTuple> {
     logger.get()->set_level(Logger::Level::off);
 
     // initialize a minimal default configuration
-    config["autopas"]["cutoff"] = 0.02;
+    config["autopas"]["cutoff"] = 80.;
+    config["sim"]["breakup"]["enabled"] = false;
     config["sim"]["deltaT"] = 1.0;
     config["sim"]["maxAltitude"] = 85000.;
     config["sim"]["prop"]["coefficientOfDrag"] = 2.2;


### PR DESCRIPTION
# Description

- [x] whole collision detection logic is only executed every N timesteps
- [x] new yaml parameter timestepsPerCollisionDetection
- [x] simulationloop return total number of collisions (for tests)

## ~Related Pull Requests~

## Resolved Issues

- [x] fixes #112 

## How Has This Been Tested?

- [x] new test
