### PR TITLE
Fix Tests

### DIFF
--- a/tests/testladds/CollisionFunctorTest.cpp
+++ b/tests/testladds/CollisionFunctorTest.cpp
@@ -254,7 +254,8 @@ TEST_P(CollisionFunctorTest, LinearInterpolationTest) {
 
   const auto &[x1, x2, v1, v2, dt, squaredExpectedDist] = GetParam();
 
-  CollisionFunctor collisionFunctor(cutoff, dt, 1., 0.1);
+  // collisionDistanceFactor > 1 to actually cover all conjunctions
+  CollisionFunctor collisionFunctor(cutoff, dt, 10., 0.1);
 
   std::vector<Particle> debris;
   debris.reserve(numDebris);


### PR DESCRIPTION
# Description

Since we actually consider object sizes some tests started to fail because objects were too small / far apart.
Some of these fails also seem to have come from confusion about what is given in `m` or `km`.
This PR strives to fix this!

## Related Pull Requests

- #115 in conjunction with its fix 6bbd3921c4782dad58343893e555664f5eba43f2

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] CI
