### PR TITLE
Improve Burn Ups

### DIFF
--- a/src/ladds/Simulation.cpp
+++ b/src/ladds/Simulation.cpp
@@ -394,7 +394,7 @@ void Simulation::dumpCalibratedConfig(ConfigReader &config, const AutoPas_t &aut
 void Simulation::deleteBurnUps(autopas::AutoPas<Particle> &autopas, double burnUpAltitude) const {
   const auto critAltitude = burnUpAltitude + Physics::R_EARTH;
   const auto critAltitudeSquared = critAltitude * critAltitude;
-  // TODO: check if it worthwhile to do this in parallel
+#pragma omp parallel
   for (auto particleIter = autopas.getRegionIterator({-critAltitude, -critAltitude, -critAltitude},
                                                      {critAltitude, critAltitude, critAltitude});
        particleIter != autopas.end();

--- a/src/ladds/Simulation.cpp
+++ b/src/ladds/Simulation.cpp
@@ -261,7 +261,7 @@ size_t Simulation::simulationLoop(AutoPas_t &autopas,
 
     // sanity check
     if (not escapedParticles.empty()) {
-      SPDLOG_LOGGER_ERROR(logger.get(), "Particles are escaping! \n{}", escapedParticles);
+      SPDLOG_LOGGER_ERROR(logger.get(), "It {} Particles are escaping! \n{}", iteration, escapedParticles);
     }
 
     if (iteration % timestepsPerCollisionDetection == 0) {
@@ -288,7 +288,6 @@ size_t Simulation::simulationLoop(AutoPas_t &autopas,
         timers.collisionSimulation.stop();
       }
     }
-
     // check if we hit the timeout and abort the loop if necessary
     if (timeout != 0) {
       // quickly interrupt timers.total to update its internal total time.

--- a/src/ladds/io/ConfigReader.h
+++ b/src/ladds/io/ConfigReader.h
@@ -119,7 +119,6 @@ class ConfigReader {
         setValueAux(config, valuePathVec.begin(), valuePathVec.end(), value);
       }
     } else if constexpr (std::is_same_v<T, bool>) {
-      const auto &v = static_cast<bool>(value);
       setValueAux(config, valuePathVec.begin(), valuePathVec.end(), value ? "true" : "false");
     } else {
       setValueAux(config, valuePathVec.begin(), valuePathVec.end(), std::to_string(value));

--- a/src/ladds/io/Timers.cpp
+++ b/src/ladds/io/Timers.cpp
@@ -20,6 +20,7 @@ void Timers::printTimers(ConfigReader &config) const {
       "  Initialization            ", initialization.getTotalTime(), maximumNumberOfDigits, timeTotal);
   std::cout << timerToString("  Simulation                ", timeSim, maximumNumberOfDigits, timeTotal);
   std::cout << timerToString("    Integrator              ", integrator.getTotalTime(), maximumNumberOfDigits, timeSim);
+  std::cout << timerToString("    Resolving Burn ups      ", burnUps.getTotalTime(), maximumNumberOfDigits, timeSim);
   std::cout << timerToString(
       "    Constellation insertion ", constellationInsertion.getTotalTime(), maximumNumberOfDigits, timeSim);
   std::cout << timerToString(


### PR DESCRIPTION
# Description

- [x] add missing timer output about burn ups
- [x] parallelize burn up detection

## How Has This Been Tested?

For 1000 iterations this brought down the time for burn up detection from 7% (0.16s) to 2% (0.03s).

