### PR TITLE
Constellation checkpointing

### DIFF
--- a/cfg/default_cfg.yaml
+++ b/cfg/default_cfg.yaml
@@ -6,7 +6,7 @@ sim:
     minutes: 0. # as floating points
     hours: 0.   # as floating points
     days: 0.    # as floating points
-  referenceTime: 2022-01-01 # calendar day associated with simulation start at iteration 0 (yyyy/mm/dd)
+  referenceTime: 2022-01-01 # calendar day associated with simulation start at iteration 0 (yyyy-mm-dd)
   maxAltitude: 10000 # Maximum satellite altitude above earth core. This number times two is the simulation box length. [km]
   minAltitude: 150 # Everything below this altitude above ground will be considered burning up [km]
   deltaT: 10.0 # [s]

--- a/src/ladds/Simulation.h
+++ b/src/ladds/Simulation.h
@@ -63,10 +63,11 @@ class Simulation {
   /**
    * Depending on config initialize readers.
    * @param config
+   * @param alreadyExistingIds a list of IDs of already existing particles. Empty if no checkpoint is loaded.
    * @return tuple<hdf5WriteFrequency, hdf5Writer, conjuctionWriter>
    */
   [[nodiscard]] std::tuple<size_t, std::shared_ptr<HDF5Writer>, std::shared_ptr<ConjuctionWriterInterface>> initWriter(
-      ConfigReader &config);
+      ConfigReader &config, std::set<size_t> &alreadyExistingIds);
 
   /**
    * Tick constellation state machines and if applicable insert new satellites as well as delayed ones from previous
@@ -77,11 +78,13 @@ class Simulation {
    * parameter!
    * @param constellationCutoff range parameter for checked insertion: if the insertion would be within a distance
    * of constellationCutoff to any other object the insertion is delayed instead
+   * @param simulationTime the current iteration
    */
   void updateConstellation(AutoPas_t &autopas,
                            std::vector<Constellation> &constellations,
                            std::vector<Particle> &delayedInsertion,
-                           double constellationCutoff);
+                           double constellationCutoff,
+                           size_t simulationTime);
 
   /**
    * Check for collisions / conjunctions and write statistics about them.

--- a/src/ladds/io/hdf5/HDF5Writer.h
+++ b/src/ladds/io/hdf5/HDF5Writer.h
@@ -29,7 +29,10 @@ class HDF5Writer final : public ConjuctionWriterInterface {
    * @param replace if true replace an existing file, else append.
    * @param compressionLevel
    */
-  HDF5Writer(const std::string &filename, bool replace, unsigned int compressionLevel);
+  HDF5Writer(const std::string &filename,
+             bool replace,
+             unsigned int compressionLevel,
+             const std::set<size_t> &alreadyExistingIds);
 
   ~HDF5Writer() override = default;
 
@@ -49,10 +52,10 @@ class HDF5Writer final : public ConjuctionWriterInterface {
 
  private:
   /**
-   * Highest partilce ID that was written in any previous iteration.
-   * For anything below this ID constant particle properties are already written.
+   * Contains particle IDs in order to add a particles constantProperties only once.
    */
-  HDF5Definitions::IntType maxWrittenParticleID{0};
+  std::set<HDF5Definitions::IntType> addedConstantPropertiesIds{};
+
 #ifdef LADDS_HDF5
   /**
    * Actual file that will be created. All of the data this writer gets ends up in this one file.

--- a/src/ladds/particle/Constellation.cpp
+++ b/src/ladds/particle/Constellation.cpp
@@ -69,6 +69,11 @@ Constellation::Constellation(ConfigReader &constellationConfig, ConfigReader &co
       schedule[i].push_back(timestamps[i] + j * timeStepSize);
     }
   }
+
+  // if checkpoint is loaded, throw away already inserted satellites
+  if (config.defines("io/hdf5/checkpoint/file")) {
+    tick(config.get<size_t>("io/hdf5/checkpoint/iteration", -1, true));
+  }
 }
 
 void Constellation::setStartTime(const std::string &startTimeStr, const std::string &refTimeStr) {
@@ -95,7 +100,7 @@ void Constellation::setDuration(const std::string &durationStr) {
   }
 }
 
-std::vector<Particle> Constellation::tick() {
+std::vector<Particle> Constellation::tick(size_t simulationTime) {
   std::vector<Particle> particles{};
   switch (status) {
     case Status::deployed:
@@ -135,7 +140,6 @@ std::vector<Particle> Constellation::tick() {
       timeActive += interval;
       break;
   }
-  simulationTime += interval;
   return particles;
 }
 

--- a/src/ladds/particle/Constellation.h
+++ b/src/ladds/particle/Constellation.h
@@ -38,7 +38,7 @@ class Constellation {
    * and linearly over time.
    * @return std::vector<Particle> : satellites to be added to the simulation.
    */
-  std::vector<Particle> tick();
+  std::vector<Particle> tick(size_t simulationTime);
 
   /**
    * Offsets all local constellation IDs by the parameter baseId to create global IDs.


### PR DESCRIPTION
# Description

-checkpointing works with constellations simply by calling tick() but not adding returned particles again
-simulationTime (a.k.a. iteration) passed to tick instead (before: calculated in Constellation class)
-BUT: assumption that later added particle always has higher id not consistent with constellations
-> different, less efficient handling of constantProperty Output: comparison with set of ids with already added particles
-> several changed function signatures necessary

# Test

Test simulation with 3 constellations with checkpointing (one added before checkpoint, second is interrupted by simulation end, third is added after checkpoint)
- consistent simulation size after checkpoint (picked up where old simulation left off)
- after simulation end: number of particles = constantProperties entries
- expected amount of particles, no particle added twice
- looked fine in paraview

