### PR TITLE
Fixing Drag Computation

### DIFF
--- a/src/ladds/Simulation.cpp
+++ b/src/ladds/Simulation.cpp
@@ -4,9 +4,9 @@
  * @date 30.11.21
  */
 
-#include "Simulation.h"
-
 #include <breakupModel/output/VTKWriter.h>
+
+#include "Simulation.h"
 
 // needed for autopas::AutoPas::getCurrentConfiguration()
 #include <autopas/AutoPasImpl.h>
@@ -237,9 +237,6 @@ size_t Simulation::simulationLoop(AutoPas_t &autopas,
 
   config.printParsedValues();
 
-  // for (auto p : autopas)
-  //   std::cout<<std::setprecision(24)<<p<<std::endl;
-
   // in tuning mode ignore the iteration counter
   for (size_t iteration = startingIteration; iteration < iterations or tuningMode; ++iteration) {
     // update positions
@@ -294,9 +291,6 @@ size_t Simulation::simulationLoop(AutoPas_t &autopas,
         timers.collisionSimulation.stop();
       }
     }
-
-    // for (auto p : autopas)
-    //   std::cout<<std::setprecision(24)<<p<<std::endl;
 
     // check if we hit the timeout and abort the loop if necessary
     if (timeout != 0) {

--- a/src/ladds/Simulation.cpp
+++ b/src/ladds/Simulation.cpp
@@ -237,6 +237,9 @@ size_t Simulation::simulationLoop(AutoPas_t &autopas,
 
   config.printParsedValues();
 
+  // for (auto p : autopas)
+  //   std::cout<<std::setprecision(24)<<p<<std::endl;
+
   // in tuning mode ignore the iteration counter
   for (size_t iteration = startingIteration; iteration < iterations or tuningMode; ++iteration) {
     // update positions
@@ -291,6 +294,10 @@ size_t Simulation::simulationLoop(AutoPas_t &autopas,
         timers.collisionSimulation.stop();
       }
     }
+
+    // for (auto p : autopas)
+    //   std::cout<<std::setprecision(24)<<p<<std::endl;
+
     // check if we hit the timeout and abort the loop if necessary
     if (timeout != 0) {
       // quickly interrupt timers.total to update its internal total time.

--- a/src/ladds/particle/Particle.cpp
+++ b/src/ladds/particle/Particle.cpp
@@ -18,8 +18,9 @@ double Particle::calculateBcInv(double bstar, double mass, double radius, double
     // or via bstar
     // @note see https://en.wikipedia.org/wiki/BSTAR
     // B* == p_0 * c_D * A / (2 m) == bc_inv * p_0 / 2
-    constexpr double p0Inv = 1. / (2.461 * 1e-5 * Physics::R_EARTH);  // 1/(kg/(m^2 * R_EARTH)) == R_EARTH * m^2/kg
-    return bstar * 2. * p0Inv;                                        // m^2/kg
+    // constexpr double p0Inv = 1. / (2.461 * 1e-5 * Physics::R_EARTH);  // 1/(kg/(m^2 * R_EARTH)) == R_EARTH * m^2/kg
+    // return bstar * 2. * p0Inv;                                        // m^2/kg
+    return 2.0 * bstar / (0.1570 / Physics::R_EARTH);
   }
 }
 
@@ -107,6 +108,8 @@ std::ostream &operator<<(std::ostream &os, const Particle &particle) {
   // clang-format off
   os << particle.toString()
      << "\nIdentifier    : " << particle.getIdentifier()
+     << "\nPos          : " << particle.getPosition()[0] << "," << particle.getPosition()[1] << "," <<  particle.getPosition()[2]
+     << "\nVel          : " << particle.getVelocity()[0] << "," << particle.getVelocity()[1] << "," <<  particle.getVelocity()[2]
      << "\nMass          : " << particle.getMass()
      << "\nRadius        : " << particle.getRadius()
      << "\nBcInv         : " << particle.getBcInv()

--- a/src/ladds/particle/Particle.cpp
+++ b/src/ladds/particle/Particle.cpp
@@ -4,10 +4,10 @@
  * @date 28.06.21
  */
 
-#include "Particle.h"
-
 #include <satellitePropagator/physics/Constants.h>
 #include <satellitePropagator/utils/MathUtils.h>
+
+#include "Particle.h"
 
 double Particle::calculateBcInv(double bstar, double mass, double radius, double coefficientOfDrag) {
   if (std::isnan(bstar) or bstar == 0.) {
@@ -18,8 +18,7 @@ double Particle::calculateBcInv(double bstar, double mass, double radius, double
     // or via bstar
     // @note see https://en.wikipedia.org/wiki/BSTAR
     // B* == p_0 * c_D * A / (2 m) == bc_inv * p_0 / 2
-    // constexpr double p0Inv = 1. / (2.461 * 1e-5 * Physics::R_EARTH);  // 1/(kg/(m^2 * R_EARTH)) == R_EARTH * m^2/kg
-    // return bstar * 2. * p0Inv;                                        // m^2/kg
+    // Thus we factor out p0 (=0.1570), convert to m (original bstar is in Earth radii) and the factor 2
     return 2.0 * bstar / (0.1570 / Physics::R_EARTH);
   }
 }


### PR DESCRIPTION
# Description

- Fixed bcinv computation (conversion from Earth radii was incorrect leading to too small values)
- More info when printing particles

## Related Pull Requests

- #132 

## Resolved Issues

- [x] fixes #134 

## How Has This Been Tested?

Attached is a population of 126 objects that decayed with SGP4 between 2022-01 and 2022-06. In the previous code only one of these decayed. In the new version, 23 of them decay within 6 month and 55 of them within 1 year. Note that SGP4 decays are [not a great ground truth](https://conference.sdo.esoc.esa.int/proceedings/sdc6/paper/41/SDC6-paper41.pdf) , so this should be taken with a grain of salt.


Test data
[decay_test_all.csv](https://github.com/esa/LADDS/files/8751672/decay_test_all.csv)

As a sanity check also ran full population for 10 000 iterations (a little > 1 day of simulation time), 8 decayed within that time but we should probably have a longer run as sanity check for this too.